### PR TITLE
Fixed a runtime error

### DIFF
--- a/libs/numeric/odeint/examples/stiff_system.cpp
+++ b/libs/numeric/odeint/examples/stiff_system.cpp
@@ -79,7 +79,7 @@ int main( int argc , char **argv )
 //    typedef rosenbrock4_controller< stepper_type > controlled_stepper_type;
 //    typedef rosenbrock4_dense_output< controlled_stepper_type > dense_output_type;
     //[ integrate_stiff_system
-    vector_type x( 3 , 1.0 );
+    vector_type x( 2 , 1.0 );
 
     size_t num_of_steps = integrate_const( make_dense_output< rosenbrock4< double > >( 1.0e-6 , 1.0e-6 ) ,
             make_pair( stiff_system() , stiff_system_jacobi() ) ,
@@ -95,7 +95,7 @@ int main( int argc , char **argv )
 //    typedef dense_output_runge_kutta< controlled_dopri5_type > dense_output_dopri5_type;
     //[ integrate_stiff_system_alternative
 
-    vector_type x2( 3 , 1.0 );
+    vector_type x2( 2 , 1.0 );
 
     size_t num_of_steps2 = integrate_const( make_dense_output< runge_kutta_dopri5< vector_type > >( 1.0e-6 , 1.0e-6 ) ,
             stiff_system() , x2 , 0.0 , 50.0 , 0.01 ,


### PR DESCRIPTION
I resized the x vector as it was causing runtime errors when trying to compute the Jacobian (due to zero line in the matrix)
