### PR TITLE
Changes in vex::multivector interface

### DIFF
--- a/boost/numeric/odeint/external/vexcl/vexcl_resize.hpp
+++ b/boost/numeric/odeint/external/vexcl/vexcl_resize.hpp
@@ -62,22 +62,22 @@ struct same_size_impl< vex::vector< T > , vex::vector< T > >
 /*
  * specializations for vex::multivector< T >
  */
-template< typename T , size_t N, bool own >
-struct is_resizeable< vex::multivector< T , N , own > > : boost::true_type { };
+template< typename T , size_t N >
+struct is_resizeable< vex::multivector< T , N > > : boost::true_type { };
 
-template< typename T , size_t N, bool own >
-struct resize_impl< vex::multivector< T , N , own > , vex::multivector< T , N , own > >
+template< typename T , size_t N >
+struct resize_impl< vex::multivector< T , N > , vex::multivector< T , N > >
 {
-    static void resize( vex::multivector< T , N , own > &x1 , const vex::multivector< T , N , own > &x2 )
+    static void resize( vex::multivector< T , N > &x1 , const vex::multivector< T , N > &x2 )
     {
         x1.resize( x2.queue_list() , x2.size() );
     }
 };
 
-template< typename T , size_t N, bool own >
-struct same_size_impl< vex::multivector< T , N , own > , vex::multivector< T , N , own > >
+template< typename T , size_t N >
+struct same_size_impl< vex::multivector< T , N > , vex::multivector< T , N > >
 {
-    static bool same_size( const vex::multivector< T , N , own > &x1 , const vex::multivector< T , N , own > &x2 )
+    static bool same_size( const vex::multivector< T , N > &x1 , const vex::multivector< T , N > &x2 )
     {
         return x1.size() == x2.size();
     }


### PR DESCRIPTION
There are no more non-owning multivectors in VexCL. vex::multivector
class has only two template parameters now: type and number of
components.

vex::tie() now returns vex::expression_tuple instead of non-owning
multivector. This allows to tie vectors of different types or even
writable expressions (e.g. slices) together.
