### PR TITLE
Remove 'own' template parameter from vex::multivector

### DIFF
--- a/boost/numeric/odeint/external/vexcl/vexcl_algebra_dispatcher.hpp
+++ b/boost/numeric/odeint/external/vexcl/vexcl_algebra_dispatcher.hpp
@@ -36,8 +36,8 @@ struct algebra_dispatcher< vex::vector< T > >
 };
 
 // specialization for vexcl multivector
-template< typename T , size_t N, bool own >
-struct algebra_dispatcher< vex::multivector< T , N , own > >
+template< typename T , size_t N >
+struct algebra_dispatcher< vex::multivector< T , N > >
 {
     typedef vector_space_algebra algebra_type;
 };

--- a/boost/numeric/odeint/external/vexcl/vexcl_norm_inf.hpp
+++ b/boost/numeric/odeint/external/vexcl/vexcl_norm_inf.hpp
@@ -76,11 +76,11 @@ struct vector_space_norm_inf< vex::vector<T> > {
 };
 
 // specialization for vexcl multivector
-template <typename T, size_t N, bool own>
-struct vector_space_norm_inf< vex::multivector<T, N, own> > {
+template <typename T, size_t N>
+struct vector_space_norm_inf< vex::multivector<T, N> > {
     typedef T result_type;
 
-    T operator()( const vex::multivector<T, N, own> &x ) const {
+    T operator()( const vex::multivector<T, N> &x ) const {
         auto max = detail::vexcl_reductor<T>(x.queue_list());
 
         // Reducing a multivector results in std::array<T, N>:


### PR DESCRIPTION
This addresses changes in VexCL multivector interface and should
solve #105 (thanks, @agerlach!).
