### PR TITLE
Include <vexcl/multivector.hpp> into vexcl_algebra_dispatcher.hpp

### DIFF
--- a/boost/numeric/odeint/external/vexcl/vexcl_algebra_dispatcher.hpp
+++ b/boost/numeric/odeint/external/vexcl/vexcl_algebra_dispatcher.hpp
@@ -19,6 +19,7 @@
 #define BOOST_NUMERIC_ODEINT_EXTERNAL_VEXCL_VEXCL_ALGEBRA_DISPATCHER_HPP_DEFINED
 
 #include <vexcl/vector.hpp>
+#include <vexcl/multivector.hpp>
 
 #include <boost/numeric/odeint/algebra/vector_space_algebra.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>


### PR DESCRIPTION
`external/vexcl/vexcl_algebra_dispatcher.hpp` uses `vex::multivector` type but does not include `vexcl/multivector.hpp`.
