### PR TITLE
Switch <iterator>-1 for --<iterator> in integrate_times() to allow use with bidirectional iterators

### DIFF
--- a/include/boost/numeric/odeint/integrate/detail/integrate_times.hpp
+++ b/include/boost/numeric/odeint/integrate/detail/integrate_times.hpp
@@ -130,8 +130,8 @@ size_t integrate_times(
     if( start_time == end_time )
         return 0;
 
-	auto last_time_iterator = end_time;
-	--last_time_iterator;
+    TimeIterator last_time_iterator = end_time;
+    --last_time_iterator;
     Time last_time_point = static_cast<time_type>(*last_time_iterator);
 
     st.initialize( start_state , *start_time , dt );

--- a/include/boost/numeric/odeint/integrate/detail/integrate_times.hpp
+++ b/include/boost/numeric/odeint/integrate/detail/integrate_times.hpp
@@ -130,7 +130,9 @@ size_t integrate_times(
     if( start_time == end_time )
         return 0;
 
-    Time last_time_point = static_cast<time_type>(*(end_time-1));
+	auto last_time_iterator = end_time;
+	--last_time_iterator;
+    Time last_time_point = static_cast<time_type>(*last_time_iterator);
 
     st.initialize( start_state , *start_time , dt );
     obs( start_state , *start_time++ );


### PR DESCRIPTION
The dense-output stepper version of integrate_times() uses
```C++
Time last_time_point = static_cast<time_type>(*(end_time-1));
```
to deduce the last time in the range it is given, but this works only if the range is delimited by random access steppers which support addition and subtraction of integers.

For my purposes I'd like to use integrate_times with a range inherited from `std::map`, which supports only bidirectional iterators. This doesn't seem a big change; it can be done just by copying the end-point iterator and decrementing it.