### PR TITLE
Fix bug in bulirsch stoer when using multiprecision data types

### DIFF
--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -412,15 +412,15 @@ private:
         BOOST_USING_STD_MAX();
         using std::pow;
 
-        value_type expo=1.0/(m_interval_sequence[k-1]);
+        value_type expo = static_cast<value_type>(1)/(m_interval_sequence[k-1]);
         value_type facmin = pow BOOST_PREVENT_MACRO_SUBSTITUTION( STEPFAC3 , expo );
         value_type fac;
         if (error == 0.0)
-            fac=1.0/facmin;
+            fac = static_cast<value_type>(1)/facmin;
         else
         {
             fac = STEPFAC2 / pow BOOST_PREVENT_MACRO_SUBSTITUTION( error / STEPFAC1 , expo );
-            fac = max BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>( facmin/STEPFAC4 ) , min BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>( 1.0/facmin ) , fac ) );
+            fac = max BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>( facmin/STEPFAC4 ) , min BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>(static_cast<value_type>(1)/facmin) , fac ) );
         }
         return h*fac;
     }

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -420,7 +420,7 @@ private:
         else
         {
             fac = STEPFAC2 / pow BOOST_PREVENT_MACRO_SUBSTITUTION( error / STEPFAC1 , expo );
-            fac = max BOOST_PREVENT_MACRO_SUBSTITUTION( facmin/STEPFAC4 , min BOOST_PREVENT_MACRO_SUBSTITUTION( 1.0/facmin , fac ) );
+            fac = max BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>( facmin/STEPFAC4 ) , min BOOST_PREVENT_MACRO_SUBSTITUTION( static_cast<value_type>( 1.0/facmin ) , fac ) );
         }
         return h*fac;
     }


### PR DESCRIPTION
I tried to make a test example in `test/` in analogy with `rosenbrock4_mp.cpp` but I encountered quite a few errors so I eventually gave up.

This patch does fix a compilation error for me in one of my projects when I switch from `double` to `cpp_dec_float_50`. (using boost 1.59.0 and g++ 4.9.2)