### PR TITLE
Limit step size

### DIFF
--- a/doc/details_generation_functions.qbk
+++ b/doc/details_generation_functions.qbk
@@ -18,7 +18,8 @@ In the __tutorial we have learned how we can use the generation functions `make_
 
 [generation_functions_syntax_auto]
 
-The first two parameters are the absolute and the relative error tolerances and the third parameter is the stepper. In C++03 you can infer the type from the `result_of` mechanism:
+The first two parameters are the absolute and the relative error tolerances and the third parameter is the stepper. Additionally, a second version exists where additionally a maximal step size is supplied which ensures the the step size is not increased above this value.
+ In C++03 you can infer the type from the `result_of` mechanism:
 
 [generation_functions_syntax_result_of]
 

--- a/examples/generation_functions.cpp
+++ b/examples/generation_functions.cpp
@@ -64,6 +64,13 @@ struct controller_factory< custom_stepper , custom_controller >
     {
         return custom_controller();
     }
+
+    custom_controller operator()( double abs_tol , double rel_tol , double max_dt ,
+                                  const custom_stepper & ) const
+    {
+        // version with maximal allowed step size max_dt
+        return custom_controller();
+    }
 };
 
 } } }
@@ -77,6 +84,9 @@ int main( int argc , char **argv )
         /*
         //[ generation_functions_syntax_auto
         auto stepper1 = make_controlled( 1.0e-6 , 1.0e-6 , stepper_type() );
+        // or with max step size limit:
+        // auto stepper1 = make_controlled( 1.0e-6 , 1.0e-6 , 0.01, stepper_type() );
+
         auto stepper2 = make_dense_output( 1.0e-6 , 1.0e-6 , stepper_type() );
         //]
         */

--- a/examples/harmonic_oscillator.cpp
+++ b/examples/harmonic_oscillator.cpp
@@ -166,7 +166,7 @@ int main(int /* argc */ , char** /* argv */ )
     //[integrate_adapt_full
     double abs_err = 1.0e-10 , rel_err = 1.0e-6 , a_x = 1.0 , a_dxdt = 1.0;
     controlled_stepper_type controlled_stepper( 
-        default_error_checker< double , double , range_algebra , default_operations >( abs_err , rel_err , a_x , a_dxdt ) );
+        default_error_checker< double , range_algebra , default_operations >( abs_err , rel_err , a_x , a_dxdt ) );
     integrate_adaptive( controlled_stepper , harmonic_oscillator , x , 0.0 , 10.0 , 0.01 );
     //]
     }

--- a/examples/harmonic_oscillator.cpp
+++ b/examples/harmonic_oscillator.cpp
@@ -166,7 +166,7 @@ int main(int /* argc */ , char** /* argv */ )
     //[integrate_adapt_full
     double abs_err = 1.0e-10 , rel_err = 1.0e-6 , a_x = 1.0 , a_dxdt = 1.0;
     controlled_stepper_type controlled_stepper( 
-        default_error_checker< double , range_algebra , default_operations >( abs_err , rel_err , a_x , a_dxdt ) );
+        default_error_checker< double , double , range_algebra , default_operations >( abs_err , rel_err , a_x , a_dxdt ) );
     integrate_adaptive( controlled_stepper , harmonic_oscillator , x , 0.0 , 10.0 , 0.01 );
     //]
     }

--- a/include/boost/numeric/odeint/integrate/detail/integrate_const.hpp
+++ b/include/boost/numeric/odeint/integrate/detail/integrate_const.hpp
@@ -117,7 +117,7 @@ size_t integrate_const(
     int obs_step( 1 );
     int real_step( 0 );
     
-    while( less_with_sign( static_cast<Time>(time+dt) , end_time , dt ) )
+    while( less_eq_with_sign( static_cast<Time>(time+dt) , end_time , dt ) )
     {
         while( less_eq_with_sign( time , st.current_time() , dt ) )
         {
@@ -148,6 +148,7 @@ size_t integrate_const(
         
     }
     // last observation, if we are still in observation interval
+    // might happen due to finite precision problems when computing the the time
     if( less_eq_with_sign( time , end_time , dt ) )
     {
         st.calc_state( time , start_state );

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
@@ -90,9 +90,11 @@ public:
 
     bulirsch_stoer(
         value_type eps_abs = 1E-6 , value_type eps_rel = 1E-6 ,
-        value_type factor_x = 1.0 , value_type factor_dxdt = 1.0 )
+        value_type factor_x = 1.0 , value_type factor_dxdt = 1.0 ,
+        time_type max_dt = static_cast<time_type>(0))
         : m_error_checker( eps_abs , eps_rel , factor_x, factor_dxdt ) , m_midpoint() ,
           m_last_step_rejected( false ) , m_first( true ) ,
+          m_max_dt(max_dt) ,
           m_interval_sequence( m_k_max+1 ) ,
           m_coeff( m_k_max+1 ) ,
           m_cost( m_k_max+1 ) ,
@@ -189,6 +191,14 @@ public:
     template< class System , class StateIn , class DerivIn , class StateOut >
     controlled_step_result try_step( System system , const StateIn &in , const DerivIn &dxdt , time_type &t , StateOut &out , time_type &dt )
     {
+        if( m_max_dt != static_cast<time_type>(0) && detail::less_with_sign(m_max_dt, dt, dt) )
+        {
+            // given step size is bigger then max_dt
+            // set limit and return fail
+            dt = m_max_dt;
+            return fail;
+        }
+
         BOOST_USING_STD_MIN();
         BOOST_USING_STD_MAX();
 
@@ -311,6 +321,11 @@ public:
 
         if( !m_last_step_rejected || boost::numeric::odeint::detail::less_with_sign(new_h, dt, dt) )
         {
+            // limit step size
+            if( m_max_dt != static_cast<time_type>(0) )
+            {
+                new_h = detail::min_abs(m_max_dt, new_h);
+            }
             m_dt_last = new_h;
             dt = new_h;
         }
@@ -474,6 +489,7 @@ private:
 
     time_type m_dt_last;
     time_type m_t_last;
+    time_type m_max_dt;
 
     size_t m_current_k_opt;
 

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
@@ -466,7 +466,7 @@ private:
             return error > 1.0;
     }
 
-    default_error_checker< value_type, algebra_type , operations_type > m_error_checker;
+    default_error_checker< value_type, time_type, algebra_type , operations_type > m_error_checker;
     modified_midpoint< state_type , value_type , deriv_type , time_type , algebra_type , operations_type , resizer_type > m_midpoint;
 
     bool m_last_step_rejected;

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
@@ -466,7 +466,7 @@ private:
             return error > 1.0;
     }
 
-    default_error_checker< value_type, time_type, algebra_type , operations_type > m_error_checker;
+    default_error_checker< value_type, algebra_type , operations_type > m_error_checker;
     modified_midpoint< state_type , value_type , deriv_type , time_type , algebra_type , operations_type , resizer_type > m_midpoint;
 
     bool m_last_step_rejected;

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -643,7 +643,7 @@ private:
 
 
 
-    default_error_checker< value_type, time_type, algebra_type , operations_type > m_error_checker;
+    default_error_checker< value_type, algebra_type , operations_type > m_error_checker;
     modified_midpoint_dense_out< state_type , value_type , deriv_type , time_type , algebra_type , operations_type , resizer_type > m_midpoint;
 
     bool m_control_interpolation;

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -643,7 +643,7 @@ private:
 
 
 
-    default_error_checker< value_type, algebra_type , operations_type > m_error_checker;
+    default_error_checker< value_type, time_type, algebra_type , operations_type > m_error_checker;
     modified_midpoint_dense_out< state_type , value_type , deriv_type , time_type , algebra_type , operations_type , resizer_type > m_midpoint;
 
     bool m_control_interpolation;

--- a/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
@@ -79,9 +79,10 @@ public:
     template< class State , class Deriv , class Err, class Time >
     value_type error( algebra_type &algebra , const State &x_old , const Deriv &dxdt_old , Err &x_err , Time dt ) const
     {
+        using std::abs;
         // this overwrites x_err !
         algebra.for_each3( x_err , x_old , dxdt_old ,
-                typename operations_type::template rel_error< value_type >( m_eps_abs , m_eps_rel , m_a_x , m_a_dxdt * get_unit_value( dt ) ) );
+                typename operations_type::template rel_error< value_type >( m_eps_abs , m_eps_rel , m_a_x , m_a_dxdt * abs(get_unit_value( dt )) ) );
 
         // value_type res = algebra.reduce( x_err ,
         //        typename operations_type::template maximum< value_type >() , static_cast< value_type >( 0 ) );

--- a/include/boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp
@@ -35,14 +35,19 @@ struct controller_factory< Stepper , controlled_runge_kutta< Stepper > >
     typedef controlled_runge_kutta< stepper_type > controller_type;
     typedef typename controller_type::error_checker_type error_checker_type;
     typedef typename stepper_type::value_type value_type;
+    typedef typename stepper_type::value_type time_type;
 
     controller_type operator()( value_type abs_error , value_type rel_error , const stepper_type &stepper )
     {
         return controller_type( error_checker_type( abs_error , rel_error ) , stepper );
     }
+
+    controller_type operator()( value_type abs_error , value_type rel_error ,
+                                time_type max_dt, const stepper_type &stepper )
+    {
+        return controller_type( error_checker_type( abs_error , rel_error , 1, 1, max_dt) , stepper );
+    }
 };
-
-
 
 
 } // odeint

--- a/include/boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp
@@ -34,18 +34,21 @@ struct controller_factory< Stepper , controlled_runge_kutta< Stepper > >
     typedef Stepper stepper_type;
     typedef controlled_runge_kutta< stepper_type > controller_type;
     typedef typename controller_type::error_checker_type error_checker_type;
+    typedef typename controller_type::step_adjuster_type step_adjuster_type;
     typedef typename stepper_type::value_type value_type;
     typedef typename stepper_type::value_type time_type;
 
     controller_type operator()( value_type abs_error , value_type rel_error , const stepper_type &stepper )
     {
-        return controller_type( error_checker_type( abs_error , rel_error ) , stepper );
+        return controller_type( error_checker_type( abs_error , rel_error ) ,
+                                step_adjuster_type() , stepper );
     }
 
     controller_type operator()( value_type abs_error , value_type rel_error ,
                                 time_type max_dt, const stepper_type &stepper )
     {
-        return controller_type( error_checker_type( abs_error , rel_error , 1, 1, max_dt) , stepper );
+        return controller_type( error_checker_type( abs_error , rel_error ) ,
+                                step_adjuster_type(max_dt) , stepper );
     }
 };
 

--- a/include/boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp
@@ -34,11 +34,20 @@ struct dense_output_factory< Stepper , dense_output_runge_kutta< controlled_rung
     typedef controlled_runge_kutta< stepper_type > controller_type;
     typedef typename controller_type::error_checker_type error_checker_type;
     typedef typename stepper_type::value_type value_type;
+    typedef typename stepper_type::time_type time_type;
     typedef dense_output_runge_kutta< controller_type > dense_output_type;
 
     dense_output_type operator()( value_type abs_error , value_type rel_error , const stepper_type &stepper )
     {
         return dense_output_type( controller_type( error_checker_type( abs_error , rel_error ) , stepper ) );
+    }
+
+    dense_output_type operator()( value_type abs_error , value_type rel_error ,
+                                  time_type max_dt , const stepper_type &stepper )
+    {
+        return dense_output_type(
+                controller_type( error_checker_type( abs_error , rel_error , 1, 1, max_dt) ,
+                                                   stepper ) );
     }
 };
 

--- a/include/boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp
@@ -33,21 +33,23 @@ struct dense_output_factory< Stepper , dense_output_runge_kutta< controlled_rung
     typedef Stepper stepper_type;
     typedef controlled_runge_kutta< stepper_type > controller_type;
     typedef typename controller_type::error_checker_type error_checker_type;
+    typedef typename controller_type::step_adjuster_type step_adjuster_type;
     typedef typename stepper_type::value_type value_type;
     typedef typename stepper_type::time_type time_type;
     typedef dense_output_runge_kutta< controller_type > dense_output_type;
 
     dense_output_type operator()( value_type abs_error , value_type rel_error , const stepper_type &stepper )
     {
-        return dense_output_type( controller_type( error_checker_type( abs_error , rel_error ) , stepper ) );
+        return dense_output_type( controller_type( error_checker_type( abs_error , rel_error ) ,
+                                                   step_adjuster_type() , stepper ) );
     }
 
     dense_output_type operator()( value_type abs_error , value_type rel_error ,
                                   time_type max_dt , const stepper_type &stepper )
     {
         return dense_output_type(
-                controller_type( error_checker_type( abs_error , rel_error , 1, 1, max_dt) ,
-                                                   stepper ) );
+                controller_type( error_checker_type( abs_error , rel_error) ,
+                                 step_adjuster_type( max_dt ) , stepper ) );
     }
 };
 

--- a/include/boost/numeric/odeint/stepper/generation/generation_rosenbrock4.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_rosenbrock4.hpp
@@ -54,11 +54,18 @@ struct dense_output_factory< Stepper , rosenbrock4_dense_output< rosenbrock4_con
     typedef Stepper stepper_type;
     typedef rosenbrock4_controller< stepper_type > controller_type;
     typedef typename stepper_type::value_type value_type;
+    typedef typename stepper_type::time_type time_type;
     typedef rosenbrock4_dense_output< controller_type > dense_output_type;
 
     dense_output_type operator()( value_type abs_error , value_type rel_error , const stepper_type &stepper )
     {
         return dense_output_type( controller_type( abs_error , rel_error , stepper ) );
+    }
+
+    dense_output_type operator()( value_type abs_error , value_type rel_error ,
+                                  time_type max_dt, const stepper_type &stepper )
+    {
+        return dense_output_type( controller_type( abs_error , rel_error , max_dt , stepper ) );
     }
 };
 

--- a/include/boost/numeric/odeint/stepper/generation/make_controlled.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/make_controlled.hpp
@@ -43,6 +43,15 @@ struct controller_factory
     {
         return Controller( abs_error , rel_error , stepper );
     }
+
+    Controller operator()(
+            typename Stepper::value_type abs_error ,
+            typename Stepper::value_type rel_error ,
+            typename Stepper::time_type max_dt ,
+            const Stepper &stepper )
+    {
+        return Controller( abs_error , rel_error , max_dt, stepper );
+    }
 };
 
 
@@ -72,6 +81,19 @@ typename result_of::make_controlled< Stepper >::type make_controlled(
 }
 
 
+template< class Stepper >
+typename result_of::make_controlled< Stepper >::type make_controlled(
+        typename Stepper::value_type abs_error ,
+        typename Stepper::value_type rel_error ,
+        typename Stepper::time_type max_dt ,
+        const Stepper & stepper = Stepper() )
+{
+    typedef Stepper stepper_type;
+    typedef typename result_of::make_controlled< stepper_type >::type controller_type;
+    typedef controller_factory< stepper_type , controller_type > factory_type;
+    factory_type factory;
+    return factory( abs_error , rel_error , max_dt, stepper );
+}
 
 } // odeint
 } // numeric

--- a/include/boost/numeric/odeint/stepper/generation/make_dense_output.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/make_dense_output.hpp
@@ -39,6 +39,15 @@ struct dense_output_factory
     {
         return DenseOutput( abs_error , rel_error , stepper );
     }
+
+    DenseOutput operator()(
+            typename Stepper::value_type abs_error ,
+            typename Stepper::value_type rel_error ,
+            typename Stepper::time_type max_dt ,
+            const Stepper &stepper )
+    {
+        return DenseOutput( abs_error , rel_error , max_dt , stepper );
+    }
 };
 
 
@@ -68,6 +77,19 @@ typename result_of::make_dense_output< Stepper >::type make_dense_output(
 }
 
 
+template< class Stepper >
+typename result_of::make_dense_output< Stepper >::type make_dense_output(
+        typename Stepper::value_type abs_error ,
+        typename Stepper::value_type rel_error ,
+        typename Stepper::time_type max_dt ,
+        const Stepper &stepper = Stepper() )
+{
+    typedef Stepper stepper_type;
+    typedef typename result_of::make_dense_output< stepper_type >::type dense_output_type;
+    typedef dense_output_factory< stepper_type , dense_output_type > factory_type;
+    factory_type factory;
+    return factory( abs_error , rel_error , max_dt, stepper );
+}
 
 
 } // odeint

--- a/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
+++ b/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
@@ -27,6 +27,7 @@
 
 #include <boost/numeric/odeint/util/copy.hpp>
 #include <boost/numeric/odeint/util/is_resizeable.hpp>
+#include <boost/numeric/odeint/util/detail/less_with_sign.hpp>
 
 #include <boost/numeric/odeint/stepper/rosenbrock4.hpp>
 
@@ -55,12 +56,20 @@ public:
     typedef rosenbrock4_controller< Stepper > controller_type;
 
 
-    rosenbrock4_controller( value_type atol = 1.0e-6 , value_type rtol = 1.0e-6 , const stepper_type &stepper = stepper_type() )
-    : m_stepper( stepper ) , m_atol( atol ) , m_rtol( rtol ) ,
-      m_first_step( true ) , m_err_old( 0.0 ) , m_dt_old( 0.0 ) ,
-      m_last_rejected( false )
+    rosenbrock4_controller( value_type atol = 1.0e-6 , value_type rtol = 1.0e-6 ,
+                            const stepper_type &stepper = stepper_type() )
+        : m_stepper( stepper ) , m_atol( atol ) , m_rtol( rtol ) ,
+          m_max_dt( static_cast<time_type>(0) ) ,
+          m_first_step( true ) , m_err_old( 0.0 ) , m_dt_old( 0.0 ) ,
+          m_last_rejected( false )
     { }
 
+    rosenbrock4_controller( value_type atol, value_type rtol, time_type max_dt,
+                            const stepper_type &stepper = stepper_type() )
+            : m_stepper( stepper ) , m_atol( atol ) , m_rtol( rtol ) , m_max_dt( max_dt ) ,
+              m_first_step( true ) , m_err_old( 0.0 ) , m_dt_old( 0.0 ) ,
+              m_last_rejected( false )
+    { }
 
     value_type error( const state_type &x , const state_type &xold , const state_type &xerr )
     {
@@ -104,6 +113,14 @@ public:
     boost::numeric::odeint::controlled_step_result
     try_step( System sys , const state_type &x , time_type &t , state_type &xout , time_type &dt )
     {
+        if( m_max_dt != static_cast<time_type>(0) && detail::less_with_sign(m_max_dt, dt, dt) )
+        {
+            // given step size is bigger then max_dt
+            // set limit and return fail
+            dt = m_max_dt;
+            return fail;
+        }
+
         BOOST_USING_STD_MIN();
         BOOST_USING_STD_MAX();
         using std::pow;
@@ -142,7 +159,11 @@ public:
                 min BOOST_PREVENT_MACRO_SUBSTITUTION ( dt_new , dt ) :
                 max BOOST_PREVENT_MACRO_SUBSTITUTION ( dt_new , dt ) );
             t += dt;
-            dt = dt_new;
+            // limit step size to max_dt
+            if( m_max_dt != static_cast<time_type>(0) )
+            {
+                dt = detail::min_abs(m_max_dt, dt_new);
+            }
             m_last_rejected = false;
             return success;
         }
@@ -198,6 +219,7 @@ private:
     wrapped_state_type m_xerr;
     wrapped_state_type m_xnew;
     value_type m_atol , m_rtol;
+    time_type m_max_dt;
     bool m_first_step;
     value_type m_err_old , m_dt_old;
     bool m_last_rejected;

--- a/include/boost/numeric/odeint/util/detail/less_with_sign.hpp
+++ b/include/boost/numeric/odeint/util/detail/less_with_sign.hpp
@@ -57,7 +57,7 @@ T min_abs( T t1 , T t2 )
 {
     BOOST_USING_STD_MIN();
     BOOST_USING_STD_MAX();
-    if( t1>0 )
+    if( get_unit_value(t1)>0 )
         return min BOOST_PREVENT_MACRO_SUBSTITUTION ( t1 , t2 );
     else
         return max BOOST_PREVENT_MACRO_SUBSTITUTION ( t1 , t2 );
@@ -68,7 +68,7 @@ T max_abs( T t1 , T t2 )
 {
     BOOST_USING_STD_MIN();
     BOOST_USING_STD_MAX();
-    if( t1>0 )
+    if( get_unit_value(t1)>0 )
         return max BOOST_PREVENT_MACRO_SUBSTITUTION ( t1 , t2 );
     else
         return min BOOST_PREVENT_MACRO_SUBSTITUTION ( t1 , t2 );

--- a/include/boost/numeric/odeint/util/detail/less_with_sign.hpp
+++ b/include/boost/numeric/odeint/util/detail/less_with_sign.hpp
@@ -6,7 +6,7 @@
  Helper function to compare times taking into account the sign of dt
  [end_description]
 
- Copyright 2012-2013 Mario Mulansky
+ Copyright 2012-2015 Mario Mulansky
  Copyright 2012 Karsten Ahnert
 
  Distributed under the Boost Software License, Version 1.0.

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -78,6 +78,7 @@ test-suite "odeint"
     [ run n_step_time_iterator.cpp ]
     [ run times_iterator.cpp ]
     [ run times_time_iterator.cpp ]
+    [ run step_size_limitation.cpp ]
     [ compile unwrap_boost_reference.cpp ]
     [ compile unwrap_reference.cpp : <cxxflags>-std=c++0x : unwrap_reference_C++11 ]
     [ compile-fail unwrap_reference.cpp : <cxxflags>-std=c++98 : unwrap_reference_C++98 ]

--- a/test/integrate.cpp
+++ b/test/integrate.cpp
@@ -97,16 +97,19 @@ struct perform_integrate_const_test
 {
     void operator()( const value_type t_end , const value_type dt )
     {
-        std::cout << "Testing integrate_const with " << typeid( Stepper ).name() << std::endl;
+        // std::cout << "Testing integrate_const with " << typeid( Stepper ).name() << std::endl;
 
         state_type x( 3 , 10.0 ) , x_end( 3 );
 
         std::vector< value_type > times;
 
         size_t steps = integrate_const( Stepper() , lorenz , x , 0.0 , t_end ,
-                         dt , push_back_time( times , x_end ) );
+                                        dt , push_back_time( times , x_end ) );
 
+        std::cout.precision(16);
         std::cout << t_end << " (" << dt << "), " << steps << " , " << times.size() << " , " << 10.0+dt*steps << "=" << x_end[0] << std::endl;
+
+        std::cout << static_cast<int>(floor(t_end/dt)) << " , " << t_end/dt << std::endl;
 
         BOOST_CHECK_EQUAL( static_cast<int>(times.size()) , static_cast<int>(floor(t_end/dt))+1 );
 
@@ -129,7 +132,7 @@ struct perform_integrate_adaptive_test
 {
     void operator()( const value_type t_end = 10.0 , const value_type dt = 0.03 )
     {
-        std::cout << "Testing integrate_adaptive with " << typeid( Stepper ).name() << std::endl;
+        // std::cout << "Testing integrate_adaptive with " << typeid( Stepper ).name() << std::endl;
 
         state_type x( 3 , 10.0 ) , x_end( 3 );
 
@@ -138,7 +141,7 @@ struct perform_integrate_adaptive_test
         size_t steps = integrate_adaptive( Stepper() , lorenz , x , 0.0 , t_end ,
                                         dt , push_back_time( times , x_end ) );
 
-        std::cout << t_end << " , " << steps << " , " << times.size() << " , " << dt << " , " << 10.0+t_end << "=" << x_end[0] << std::endl;
+        // std::cout << t_end << " , " << steps << " , " << times.size() << " , " << dt << " , " << 10.0+t_end << "=" << x_end[0] << std::endl;
 
         BOOST_CHECK_EQUAL( times.size() , steps+1 );
 
@@ -158,7 +161,7 @@ struct perform_integrate_times_test
 {
     void operator()( const int n = 10 , const int dn=1 , const value_type dt = 0.03 )
     {
-        std::cout << "Testing integrate_times with " << typeid( Stepper ).name() << std::endl;
+        // std::cout << "Testing integrate_times with " << typeid( Stepper ).name() << std::endl;
 
         state_type x( 3 ) , x_end( 3 );
         x[0] = x[1] = x[2] = 10.0;
@@ -194,7 +197,8 @@ struct perform_integrate_n_steps_test
 {
     void operator()( const int n = 200 , const value_type dt = 0.01 )
     {
-        std::cout << "Testing integrate_n_steps with " << typeid( Stepper ).name() << std::endl;
+        // std::cout << "Testing integrate_n_steps with " << typeid( Stepper ).name() << ". ";
+        // std::cout << "dt=" << dt << std::endl;
 
         state_type x( 3 ) , x_end( 3 );
         x[0] = x[1] = x[2] = 10.0;
@@ -208,9 +212,10 @@ struct perform_integrate_n_steps_test
         BOOST_CHECK_EQUAL( static_cast<int>(times.size()) , n+1 );
 
         for( size_t i=0 ; i<times.size() ; ++i )
+        {
             // check if observer was called at times 0,1,2,...
-            BOOST_CHECK_SMALL( times[i] - static_cast< value_type >(i)*dt , 2E-16 );
-
+            BOOST_CHECK_SMALL(times[i] - static_cast< value_type >(i) * dt, 2E-16);
+        }
         // check first, trivial, component
         BOOST_CHECK_SMALL( (10.0 + end_time) - x_end[0] , 1E-6 ); // precision of steppers: 1E-6
 //        BOOST_CHECK_EQUAL( x[1] , x_end[1] );

--- a/test/step_size_limitation.cpp
+++ b/test/step_size_limitation.cpp
@@ -58,45 +58,45 @@ struct push_back_time
 
 BOOST_AUTO_TEST_SUITE( step_size_limitation_test )
 
-BOOST_AUTO_TEST_CASE( test_error_checker )
+BOOST_AUTO_TEST_CASE( test_step_adjuster )
 {
-    // first use checker without step size limitation
-    default_error_checker<double, double, range_algebra, default_operations> checker;
+    // first use adjuster without step size limitation
+    default_step_adjuster<double, double> step_adjuster;
     const double dt = 0.1;
-    double dt_new = checker.decrease_step(dt, 1.5, 2);
+    double dt_new = step_adjuster.decrease_step(dt, 1.5, 2);
     BOOST_CHECK(dt_new < dt*2.0/3.0);
 
-    dt_new = checker.increase_step(dt, 0.8, 1);
+    dt_new = step_adjuster.increase_step(dt, 0.8, 1);
     // for errors > 0.5 no increase is performed
     BOOST_CHECK(dt_new == dt);
 
-    dt_new = checker.increase_step(dt, 0.4, 1);
+    dt_new = step_adjuster.increase_step(dt, 0.4, 1);
     // smaller errors should lead to step size increase
     std::cout << dt_new << std::endl;
     BOOST_CHECK(dt_new > dt);
 
 
     // now test with step size limitation max_dt = 0.1
-    default_error_checker<double, double, range_algebra, default_operations>
-        limited_checker(1E-6, 1E-6, 1, 1, dt);
+    default_step_adjuster<double, double>
+        limited_adjuster(dt);
 
-    dt_new = limited_checker.decrease_step(dt, 1.5, 2);
+    dt_new = limited_adjuster.decrease_step(dt, 1.5, 2);
     // decreasing works as before
     BOOST_CHECK(dt_new < dt*2.0/3.0);
 
-    dt_new = limited_checker.decrease_step(2*dt, 1.1, 2);
+    dt_new = limited_adjuster.decrease_step(2*dt, 1.1, 2);
     // decreasing a large step size should give max_dt
     BOOST_CHECK(dt_new == dt);
 
-    dt_new = limited_checker.increase_step(dt, 0.8, 1);
+    dt_new = limited_adjuster.increase_step(dt, 0.8, 1);
     // for errors > 0.5 no increase is performed, still valid
     BOOST_CHECK(dt_new == dt);
 
-    dt_new = limited_checker.increase_step(dt, 0.4, 1);
+    dt_new = limited_adjuster.increase_step(dt, 0.4, 1);
     // but even for smaller errors, we should at most get 0.1
     BOOST_CHECK(dt_new == dt);
 
-    dt_new = limited_checker.increase_step(0.9*dt, 0.1, 1);
+    dt_new = limited_adjuster.increase_step(0.9*dt, 0.1, 1);
     std::cout << dt_new << std::endl;
     // check that we don't increase beyond max_dt
     BOOST_CHECK(dt_new == dt);

--- a/test/step_size_limitation.cpp
+++ b/test/step_size_limitation.cpp
@@ -1,0 +1,179 @@
+/*
+ [auto_generated]
+ libs/numeric/odeint/test/step_size_limitation.cpp
+
+ [begin_description]
+ Tests the step size limitation functionality
+ [end_description]
+
+ Copyright 2015 Mario Mulansky
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#define BOOST_TEST_MODULE odeint_integrate_times
+
+#include <boost/test/unit_test.hpp>
+
+#include <utility>
+#include <iostream>
+#include <vector>
+
+#include <boost/numeric/odeint.hpp>
+
+using namespace boost::unit_test;
+using namespace boost::numeric::odeint;
+
+typedef double value_type;
+typedef std::vector< value_type > state_type;
+
+
+void lorenz( const state_type &x , state_type &dxdt , const value_type t )
+{
+    BOOST_CHECK( t >= 0.0 );
+
+    const value_type sigma( 10.0 );
+    const value_type R( 28.0 );
+    const value_type b( value_type( 8.0 ) / value_type( 3.0 ) );
+
+    dxdt[0] = sigma * ( x[1] - x[0] );
+    dxdt[1] = R * x[0] - x[1] - x[0] * x[2];
+    dxdt[2] = -b * x[2] + x[0] * x[1];
+}
+
+struct push_back_time
+{
+    std::vector< double >& m_times;
+
+    push_back_time( std::vector< double > &times )
+    :  m_times( times ) { }
+
+    void operator()( const state_type &x , double t )
+    {
+        m_times.push_back( t );
+    }
+};
+
+BOOST_AUTO_TEST_SUITE( step_size_limitation_test )
+
+BOOST_AUTO_TEST_CASE( test_error_checker )
+{
+    // first use checker without step size limitation
+    default_error_checker<double, double, range_algebra, default_operations> checker;
+    const double dt = 0.1;
+    double dt_new = checker.decrease_step(dt, 1.5, 2);
+    BOOST_CHECK(dt_new < dt*2.0/3.0);
+
+    dt_new = checker.increase_step(dt, 0.8, 1);
+    // for errors > 0.5 no increase is performed
+    BOOST_CHECK(dt_new == dt);
+
+    dt_new = checker.increase_step(dt, 0.4, 1);
+    // smaller errors should lead to step size increase
+    std::cout << dt_new << std::endl;
+    BOOST_CHECK(dt_new > dt);
+
+
+    // now test with step size limitation max_dt = 0.1
+    default_error_checker<double, double, range_algebra, default_operations>
+        limited_checker(1E-6, 1E-6, 1, 1, dt);
+
+    dt_new = limited_checker.decrease_step(dt, 1.5, 2);
+    // decreasing works as before
+    BOOST_CHECK(dt_new < dt*2.0/3.0);
+
+    dt_new = limited_checker.decrease_step(2*dt, 1.1, 2);
+    // decreasing a large step size should give max_dt
+    BOOST_CHECK(dt_new == dt);
+
+    dt_new = limited_checker.increase_step(dt, 0.8, 1);
+    // for errors > 0.5 no increase is performed, still valid
+    BOOST_CHECK(dt_new == dt);
+
+    dt_new = limited_checker.increase_step(dt, 0.4, 1);
+    // but even for smaller errors, we should at most get 0.1
+    BOOST_CHECK(dt_new == dt);
+
+    dt_new = limited_checker.increase_step(0.9*dt, 0.1, 1);
+    std::cout << dt_new << std::endl;
+    // check that we don't increase beyond max_dt
+    BOOST_CHECK(dt_new == dt);
+}
+
+
+BOOST_AUTO_TEST_CASE( test_controlled )
+{
+    state_type x( 3 );
+    x[0] = x[1] = x[2] = 10.0;
+    const double max_dt = 0.01;
+
+    std::vector<double> times;
+
+    integrate_adaptive(make_controlled(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
+                       lorenz, x, 0.0, 1.0, max_dt, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+        // check if observer was called at times 0,1,2,...
+        BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+
+    // this should also work when we provide some bigger initial dt
+    integrate_adaptive(make_controlled(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
+                       lorenz, x, 0.0, 1.0, 0.1, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+    // check if observer was called at times 0,1,2,...
+    BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+
+    // check this behavior with cash karp
+    integrate_adaptive(make_controlled(1E-2, 1E-2, max_dt, runge_kutta_cash_karp54<state_type>()),
+                       lorenz, x, 0.0, 1.0, max_dt, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+        // check if observer was called at times 0,1,2,...
+        BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+
+    // this should also work when we provide some bigger initial dt
+    integrate_adaptive(make_controlled(1E-2, 1E-2, max_dt, runge_kutta_cash_karp54<state_type>()),
+                       lorenz, x, 0.0, 1.0, 0.1, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+        // check if observer was called at times 0,1,2,...
+        BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+
+}
+
+
+
+BOOST_AUTO_TEST_CASE( test_dense_out )
+{
+    state_type x( 3 );
+    x[0] = x[1] = x[2] = 10.0;
+    const double max_dt = 0.01;
+
+    std::vector<double> times;
+
+    integrate_adaptive(make_dense_output(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
+                      lorenz, x, 0.0, 1.0, max_dt, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+        // check if observer was called at times 0,1,2,...
+        BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+
+    // this should also work when we provide some bigger initial dt
+    integrate_adaptive(make_dense_output(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
+                       lorenz, x, 0.0, 1.0, 0.1, push_back_time(times));
+    // check that dt remains at exactly max_dt
+    for( size_t i=0 ; i<times.size() ; ++i )
+        // check if observer was called at times 0,1,2,...
+        BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
+    times.clear();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/step_size_limitation.cpp
+++ b/test/step_size_limitation.cpp
@@ -29,6 +29,10 @@ using namespace boost::numeric::odeint;
 typedef double value_type;
 typedef std::vector< value_type > state_type;
 
+/***********************************************
+ * first part of the tests: explicit methods
+ ***********************************************
+ */
 
 void damped_osc( const state_type &x , state_type &dxdt , const value_type t )
 {
@@ -46,7 +50,8 @@ struct push_back_time
     push_back_time( std::vector< double > &times )
     :  m_times( times ) { }
 
-    void operator()( const state_type &x , double t )
+    template<typename State>
+    void operator()( const State &x , double t )
     {
         m_times.push_back( t );
     }
@@ -90,7 +95,7 @@ BOOST_AUTO_TEST_CASE( test_step_adjuster )
 
     dt_new = limited_adjuster.increase_step(dt, 0.4, 1);
     // but even for smaller errors, we should at most get 0.1
-    BOOST_CHECK(dt_new == dt);
+    BOOST_CHECK_EQUAL(dt_new, dt);
 
     dt_new = limited_adjuster.increase_step(0.9*dt, 0.1, 1);
     std::cout << dt_new << std::endl;
@@ -99,27 +104,28 @@ BOOST_AUTO_TEST_CASE( test_step_adjuster )
 }
 
 
-template<class ControlledStepper>
-void test_controlled_stepper(ControlledStepper stepper, const double max_dt)
+template<class Stepper>
+void test_explicit_stepper(Stepper stepper, const double max_dt)
 {
     state_type x( 2 );
     x[0] = x[1] = 10.0;
+    const size_t steps = 100;
 
     std::vector<double> times;
 
-    integrate_adaptive(stepper, damped_osc, x, 0.0, 100*max_dt, max_dt, push_back_time(times));
+    integrate_adaptive(stepper, damped_osc, x, 0.0, steps*max_dt, max_dt, push_back_time(times));
+
+    BOOST_CHECK_EQUAL(times.size(), steps+1);
     // check that dt remains at exactly max_dt
-
-    std::cout << "STEP: " << times.size() << " , END: " << times[times.size()-1] << std::endl;
-
     for( size_t i=0 ; i<times.size() ; ++i )
         // check if observer was called at times 0,1,2,...
         BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
     times.clear();
 
-    return;
     // this should also work when we provide some bigger initial dt
-    integrate_adaptive(stepper, damped_osc, x, 0.0, 100*max_dt, 10*max_dt, push_back_time(times));
+    integrate_adaptive(stepper, damped_osc, x, 0.0, steps*max_dt, 10*max_dt, push_back_time(times));
+
+    BOOST_CHECK_EQUAL(times.size(), steps+1);
     // check that dt remains at exactly max_dt
     for( size_t i=0 ; i<times.size() ; ++i )
         // check if observer was called at times 0,1,2,...
@@ -132,41 +138,92 @@ BOOST_AUTO_TEST_CASE( test_controlled )
 {
     const double max_dt = 0.01;
 
-    test_controlled_stepper(make_controlled(1E-2, 1E-2, max_dt,
+    test_explicit_stepper(make_controlled(1E-2, 1E-2, max_dt,
                                             runge_kutta_dopri5<state_type>()),
                             max_dt);
-    test_controlled_stepper(make_controlled(1E-2, 1E-2, -max_dt,
+    test_explicit_stepper(make_controlled(1E-2, 1E-2, -max_dt,
                                             runge_kutta_dopri5<state_type>()),
                             -max_dt);
-    std::cout << "DOPRI5 FINISHED" << std::endl;
 
-    test_controlled_stepper(make_controlled(1E-2, 1E-2, max_dt,
+    test_explicit_stepper(make_controlled(1E-2, 1E-2, max_dt,
                                             runge_kutta_cash_karp54<state_type>()),
                             max_dt);
-    test_controlled_stepper(make_controlled(1E-2, 1E-2, -max_dt,
+    test_explicit_stepper(make_controlled(1E-2, 1E-2, -max_dt,
                                             runge_kutta_cash_karp54<state_type>()),
                             -max_dt);
-    std::cout << "RK-CK54 FINISHED" << std::endl;
 
-    test_controlled_stepper(bulirsch_stoer<state_type>(1E-2, 1E-2, 1.0, 1.0, max_dt),
+    test_explicit_stepper(bulirsch_stoer<state_type>(1E-2, 1E-2, 1.0, 1.0, max_dt),
                             max_dt);
-    test_controlled_stepper(bulirsch_stoer<state_type>(1E-2, 1E-2, 1.0, 1.0, -max_dt),
+    test_explicit_stepper(bulirsch_stoer<state_type>(1E-2, 1E-2, 1.0, 1.0, -max_dt),
                             -max_dt);
-    std::cout << "BS FINISHED" << std::endl;
 }
-
 
 
 BOOST_AUTO_TEST_CASE( test_dense_out )
 {
-    state_type x( 2 );
-    x[0] = x[1] = 10.0;
     const double max_dt = 0.01;
+    test_explicit_stepper(make_dense_output(1E-2, 1E-2, max_dt,
+                                             runge_kutta_dopri5<state_type>()),
+                          max_dt);
+    test_explicit_stepper(make_dense_output(1E-2, 1E-2, -max_dt,
+                                            runge_kutta_dopri5<state_type>()),
+                          -max_dt);
+
+    test_explicit_stepper(bulirsch_stoer_dense_out<state_type>(1E-2, 1E-2, 1, 1, max_dt),
+                          max_dt);
+
+    test_explicit_stepper(bulirsch_stoer_dense_out<state_type>(1E-2, 1E-2, 1, 1, -max_dt),
+                          -max_dt);
+}
+
+
+/***********************************************
+ * second part of the tests: implicit Rosenbrock
+ ***********************************************
+ */
+
+typedef boost::numeric::ublas::vector< value_type > vector_type;
+typedef boost::numeric::ublas::matrix< value_type > matrix_type;
+
+
+// harmonic oscillator, analytic solution x[0] = sin( t )
+struct osc_rhs
+{
+    void operator()( const vector_type &x , vector_type &dxdt , const value_type &t ) const
+    {
+        dxdt( 0 ) = x( 1 );
+        dxdt( 1 ) = -x( 0 );
+    }
+};
+
+struct osc_jacobi
+{
+    void operator()( const vector_type &x , matrix_type &jacobi , const value_type &t , vector_type &dfdt ) const
+    {
+        jacobi( 0 , 0 ) = 0;
+        jacobi( 0 , 1 ) = 1;
+        jacobi( 1 , 0 ) = -1;
+        jacobi( 1 , 1 ) = 0;
+        dfdt( 0 ) = 0.0;
+        dfdt( 1 ) = 0.0;
+    }
+};
+
+
+template<class Stepper>
+void test_rosenbrock_stepper(Stepper stepper, const double max_dt)
+{
+    vector_type x( 2 );
+    x(0) = x(1) = 10.0;
+    const size_t steps = 100;
 
     std::vector<double> times;
 
-    integrate_adaptive(make_dense_output(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
-                       damped_osc, x, 0.0, 1.0, max_dt, push_back_time(times));
+    integrate_adaptive(stepper,
+                       std::make_pair(osc_rhs(), osc_jacobi()),
+                       x, 0.0, steps*max_dt, max_dt, push_back_time(times));
+
+    BOOST_CHECK_EQUAL(times.size(), steps+1);
     // check that dt remains at exactly max_dt
     for( size_t i=0 ; i<times.size() ; ++i )
         // check if observer was called at times 0,1,2,...
@@ -174,13 +231,38 @@ BOOST_AUTO_TEST_CASE( test_dense_out )
     times.clear();
 
     // this should also work when we provide some bigger initial dt
-    integrate_adaptive(make_dense_output(1E-2, 1E-2, max_dt, runge_kutta_dopri5<state_type>()),
-                       damped_osc, x, 0.0, 1.0, 0.1, push_back_time(times));
+    integrate_adaptive(stepper,
+                       std::make_pair(osc_rhs(), osc_jacobi()),
+                       x, 0.0, steps*max_dt, 10*max_dt, push_back_time(times));
+
+    BOOST_CHECK_EQUAL(times.size(), steps+1);
     // check that dt remains at exactly max_dt
     for( size_t i=0 ; i<times.size() ; ++i )
         // check if observer was called at times 0,1,2,...
         BOOST_CHECK_SMALL( times[i] - static_cast<double>(i)*max_dt , 1E-15);
     times.clear();
+}
+
+
+BOOST_AUTO_TEST_CASE( test_controlled_rosenbrock )
+{
+    const double max_dt = 0.01;
+
+    test_rosenbrock_stepper(make_controlled(1E-2, 1E-2, max_dt, rosenbrock4<value_type>()),
+                            max_dt);
+    test_rosenbrock_stepper(make_controlled(1E-2, 1E-2, -max_dt, rosenbrock4<value_type>()),
+                            -max_dt);
+}
+
+
+BOOST_AUTO_TEST_CASE( test_dense_out_rosenbrock )
+{
+    const double max_dt = 0.01;
+
+    test_rosenbrock_stepper(make_dense_output(1E-2, 1E-2, max_dt, rosenbrock4<value_type>()),
+                            max_dt);
+    test_rosenbrock_stepper(make_dense_output(1E-2, 1E-2, -max_dt, rosenbrock4<value_type>()),
+                            -max_dt);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Extends the error_checker to also handle step size adjustment, which was done before in the try_step method. Furthermore, the default_error_checker now provides the possibility to limit the step size to some maximal value, independent from the error. This has been requested in #122 