### PR TITLE
Switch fabs for std::abs in new adaptive Adams-Bashforth-Moulton stepper

### DIFF
--- a/include/boost/numeric/odeint/stepper/controlled_adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/controlled_adams_bashforth_moulton.hpp
@@ -41,9 +41,11 @@ public:
 
     void adjust_order(size_t &order, const boost::array<wrapped_state_type, 3> & xerr)
     {
-        value_type errm = fabs(m_algebra.norm_inf(xerr[0].m_v));
-        value_type errc = fabs(m_algebra.norm_inf(xerr[1].m_v));
-        value_type errp = fabs(m_algebra.norm_inf(xerr[2].m_v));
+        using std::abs;
+
+        value_type errm = abs(m_algebra.norm_inf(xerr[0].m_v));
+        value_type errc = abs(m_algebra.norm_inf(xerr[1].m_v));
+        value_type errp = abs(m_algebra.norm_inf(xerr[2].m_v));
 
         if(order == 1)
         {   

--- a/include/boost/numeric/odeint/stepper/detail/adaptive_adams_coefficients.hpp
+++ b/include/boost/numeric/odeint/stepper/detail/adaptive_adams_coefficients.hpp
@@ -69,9 +69,11 @@ public:
 
     void predict(time_type t, time_type dt)
     {
+        using std::abs;
+
         m_time_storage[0] = t;
 
-        if (fabs(m_time_storage[0] - m_time_storage[1] - dt) > 1e-16 || m_eo >= m_ns)
+        if (abs(m_time_storage[0] - m_time_storage[1] - dt) > 1e-16 || m_eo >= m_ns)
         {
             m_ns = 0;
         }

--- a/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster.hpp
+++ b/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster.hpp
@@ -46,11 +46,13 @@ public:
     template<class T1, class T2, class T3, class T4>
     void operator()(T1 &t1, const T2 &t2, const T3 &t3, const T4 &t4)
     {
-        t1 = adapted_pow(fabs(t2), -beta1/(m_steps + 1)) *
-            adapted_pow(fabs(t3), -beta2/(m_steps + 1)) *
-            adapted_pow(fabs(t4), -beta3/(m_steps + 1)) *
-            adapted_pow(fabs(dt1/dt2), -alpha1/(m_steps + 1))*
-            adapted_pow(fabs(dt2/dt3), -alpha2/(m_steps + 1));
+        using std::abs;
+
+        t1 = adapted_pow(abs(t2), -beta1/(m_steps + 1)) *
+            adapted_pow(abs(t3), -beta2/(m_steps + 1)) *
+            adapted_pow(abs(t4), -beta3/(m_steps + 1)) *
+            adapted_pow(abs(dt1/dt2), -alpha1/(m_steps + 1))*
+            adapted_pow(abs(dt2/dt3), -alpha2/(m_steps + 1));
 
         t1 = 1/t1;
     };
@@ -58,7 +60,9 @@ public:
     template<class T1, class T2>
     void operator()(T1 &t1, const T2 &t2)
     {
-        t1 = adapted_pow(fabs(t2), -beta1/(m_steps + 1));
+        using std::abs;
+
+        t1 = adapted_pow(abs(t2), -beta1/(m_steps + 1));
 
         t1 = 1/t1;
     };


### PR DESCRIPTION
I have been experimenting with the new adaptive Adams-Bashforth-Moulton stepper recently merged into odeint-v2. However, I've noticed that it doesn't play so well with floating-point value types other than `double` because some code in `controlled_adams_bashforth_moulton.hpp`, `adaptive_adams_coefficients.hpp` and `pid_step_adjuster.hpp` extract absolute values using `fabs()` without a namespace qualifier.

My understanding is that unqualified `fabs()` doesn't have overloads for types other than double (eg. http://www.cplusplus.com/reference/cmath/fabs/) — for example, at least on my platform there is already a problem at the level of using `long double` which clang warns will be implicitly narrowed to `double`. My understanding is that only `std::fabs()` or `std::abs()` have overloads for other types, and this seems to fit with the rest of odeint-v2 where `std::abs()` is normally used except for some parts of the `vexcl` interface.

This patch changes the uses of `fabs()` for `std::abs()` in just the three files mentioned at the top.