### PR TITLE
Fix initialization of adams bashforth moulton stepper with external stepper

### DIFF
--- a/include/boost/numeric/odeint/stepper/adaptive_adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/adaptive_adams_bashforth_moulton.hpp
@@ -113,16 +113,23 @@ public:
     template< class ExplicitStepper, class System >
     void initialize(ExplicitStepper stepper, System system, state_type &inOut, time_type &t, time_type dt)
     {
+        reset();
+        dt = dt/static_cast< time_type >(order_value);
+
         m_dxdt_resizer.adjust_size( inOut , detail::bind( &stepper_type::template resize_dxdt_impl< state_type > , detail::ref( *this ) , detail::_1 ) );
 
+        system( inOut , m_dxdt.m_v , t );
         for( size_t i=0 ; i<order_value; ++i )
         {
-            system( inOut , m_dxdt.m_v , t );
-            stepper.do_step_dxdt_impl( system, inOut, m_dxdt.m_v, t, dt/static_cast< Time >(order_value) );
+            stepper.do_step_dxdt_impl( system, inOut, m_dxdt.m_v, t, dt );
             
-            m_coeff.predict(t, dt/static_cast< Time >(order_value));
+            system( inOut , m_dxdt.m_v , t + dt);
+            
+            m_coeff.predict(t, dt);
             m_coeff.do_step(m_dxdt.m_v);
             m_coeff.confirm();
+            
+            t += dt;
 
             if(m_coeff.m_eo < order_value)
             {
@@ -134,10 +141,13 @@ public:
     template< class System >
     void initialize(System system, state_type &inOut, time_type &t, time_type dt)
     {
+        reset();
+        dt = dt/static_cast< time_type >(order_value);
+
         for(size_t i=0; i<order_value; ++i)
         {
-            this->do_step(system, inOut, t, dt/static_cast< Time >(order_value));
-            t += dt/static_cast< Time >(order_value);
+            this->do_step(system, inOut, t, dt);
+            t += dt;
         };
     };
 

--- a/test/numeric/adaptive_adams_bashforth_moulton.cpp
+++ b/test/numeric/adaptive_adams_bashforth_moulton.cpp
@@ -68,12 +68,7 @@ struct perform_adaptive_adams_bashforth_moulton_test
         stepper.initialize( init_stepper, osc() , x1 , t ,  dt);
         double A = std::sqrt( x1[0]*x1[0] + x1[1]*x1[1] );
         double phi = std::asin(x1[0]/A) - t;
-        // more steps necessary to "counteract" the effect from the lower order steps
-        for( size_t n=0 ; n < stepper.steps ; ++n )
-        {
-            stepper.do_step( osc() , x1 , t , dt );
-            t += dt;
-        }
+        
         // now we do the actual step
         stepper.do_step( osc() , x1 , t , dt );
         // only examine the error of the adams-bashforth step, not the initialization


### PR DESCRIPTION
The initialization with an external stepper lead to NaN everywhere very quickly, since the time was not increased over the iterations. In addition, the "wrong" derivative was taken for the initialization of the adaptive coefficients (the derivative before taking the step instead of after taking the step with the external stepper).

The numeric test was adapted to this change as well. The additional "initialization steps" after the actual initialization are not necessary anymore.

This bugfix corrects both issues.