### PR TITLE
Controlled initialization of the controlled adams bashforth moulton stepper

### DIFF
--- a/include/boost/numeric/odeint/stepper/adaptive_adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/adaptive_adams_bashforth_moulton.hpp
@@ -1,3 +1,18 @@
+/*
+ boost/numeric/odeint/stepper/detail/adaptive_adams_bashforth_moulton.hpp
+
+ [begin_description]
+ Implemetation of an adaptive adams bashforth moulton stepper.
+ Used as the stepper for the controlled adams bashforth moulton stepper.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 #ifndef BOOST_NUMERIC_ODEINT_STEPPER_ADAPTIVE_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_STEPPER_ADAPTIVE_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 

--- a/include/boost/numeric/odeint/stepper/controlled_adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/controlled_adams_bashforth_moulton.hpp
@@ -1,3 +1,17 @@
+/*
+ boost/numeric/odeint/stepper/detail/controlled_adams_bashforth_moulton.hpp
+
+ [begin_description]
+ Implemetation of an controlled adams bashforth moulton stepper.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
 #ifndef BOOST_NUMERIC_ODEINT_STEPPER_CONTROLLED_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_STEPPER_CONTROLLED_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 
@@ -140,6 +154,37 @@ public:
     {
         m_stepper.initialize(system, inOut, t, dt);
     };
+
+    template< class ExplicitStepper, class System >
+    void initialize_controlled(ExplicitStepper stepper, System system, state_type &inOut, time_type &t, time_type &dt)
+    {
+        reset();
+        coeff_type &coeff = m_stepper.coeff();
+
+        m_dxdt_resizer.adjust_size( inOut , detail::bind( &controlled_stepper_type::template resize_dxdt_impl< state_type > , detail::ref( *this ) , detail::_1 ) );
+
+        controlled_step_result res = fail;
+
+        for( size_t i=0 ; i<order_value; ++i )
+        {
+            do
+            {
+                res = stepper.try_step( system, inOut, t, dt );
+            }
+            while(res != success);
+
+            system( inOut , m_dxdt.m_v , t );
+            
+            coeff.predict(t-dt, dt);
+            coeff.do_step(m_dxdt.m_v);
+            coeff.confirm();
+
+            if(coeff.m_eo < order_value)
+            {
+                ++coeff.m_eo;
+            }
+        }
+    }
 
     template< class System >
     controlled_step_result try_step(System system, state_type & inOut, time_type &t, time_type &dt)

--- a/include/boost/numeric/odeint/stepper/detail/adaptive_adams_coefficients.hpp
+++ b/include/boost/numeric/odeint/stepper/detail/adaptive_adams_coefficients.hpp
@@ -1,3 +1,17 @@
+/*
+ boost/numeric/odeint/stepper/detail/adaptive_adams_coefficients.hpp
+
+ [begin_description]
+ Calculation of the coefficients for the adaptive adams stepper.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 #ifndef BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_ADAPTIVE_ADAMS_COEFFICIENTS_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_ADAPTIVE_ADAMS_COEFFICIENTS_HPP_INCLUDED
 

--- a/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster.hpp
+++ b/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster.hpp
@@ -1,3 +1,17 @@
+/*
+ boost/numeric/odeint/stepper/detail/pid_step_adjuster.hpp
+
+ [begin_description]
+ Implementation of the stepsize controller for the controlled adams bashforth moulton stepper.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 #ifndef BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_PID_STEP_ADJUSTER_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_PID_STEP_ADJUSTER_HPP_INCLUDED
 

--- a/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster_coefficients.hpp
+++ b/include/boost/numeric/odeint/stepper/detail/pid_step_adjuster_coefficients.hpp
@@ -1,3 +1,17 @@
+/*
+ boost/numeric/odeint/stepper/detail/pid_step_adjuster_coefficients.hpp
+
+ [begin_description]
+ Coefficients for the PID stepsize controller.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 #ifndef BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_PID_STEP_ADJUSTER_COEFFICIENTS_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_STEPPER_DETAIL_PID_STEP_ADJUSTER_COEFFICIENTS_HPP_INCLUDED
 

--- a/include/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_moulton.hpp
@@ -1,3 +1,17 @@
+/*
+ boost/numeric/odeint/stepper/detail/generation_controlled_adams_bashforth_moulton.hpp
+
+ [begin_description]
+ Spezialization of the generation functions for creation of the controlled adams bashforth moulton stepper.
+ [end_description]
+
+ Copyright 2017 Valentin Noah Hartmann
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
 #ifndef GENERATION_CONTROLLED_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 #define GENERATION_CONTROLLED_ADAMS_BASHFORTH_MOULTON_HPP_INCLUDED
 


### PR DESCRIPTION
The basic `initialize` method takes fixed stepsizes. Even when working with a higher order stepper, this might lead to relatively big errors during the first few steps.

`initialize_controlled` takes advantage of the `try_step` method of controlled steppers during the initialization of the controlled adams bashforth moulton stepper.

Additionally added the boost licence information on top of all the files.