### PR TITLE
Enable the adaption of the maximal step size of dense output steppers.

### DIFF
--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -393,6 +393,11 @@ public:
 
 protected:
 
+    time_type m_max_dt;
+
+
+private:
+
     template< class StateInOut , class StateVector >
     void extrapolate( size_t k , StateVector &table , const value_matrix &coeff , StateInOut &xest , size_t order_start_index = 0 )
     //polynomial extrapolation, see http://www.nr.com/webnotes/nr3web21.pdf
@@ -666,8 +671,6 @@ protected:
 
     default_error_checker< value_type, algebra_type , operations_type > m_error_checker;
     modified_midpoint_dense_out< state_type , value_type , deriv_type , time_type , algebra_type , operations_type , resizer_type > m_midpoint;
-
-    time_type m_max_dt;
 
     bool m_control_interpolation;
 

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -391,7 +391,7 @@ public:
     }
 
 
-private:
+protected:
 
     template< class StateInOut , class StateVector >
     void extrapolate( size_t k , StateVector &table , const value_matrix &coeff , StateInOut &xest , size_t order_start_index = 0 )

--- a/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
@@ -163,7 +163,7 @@ public:
 
     time_type get_max_dt() { return m_max_dt; }
 
-private:
+protected:
     time_type m_max_dt;
 };
 
@@ -411,10 +411,11 @@ public:
     template< class System , class StateIn , class DerivIn , class StateOut >
     controlled_step_result try_step( System system , const StateIn &in , const DerivIn &dxdt , time_type &t , StateOut &out , time_type &dt )
     {
-        if( !m_step_adjuster.check_step_size_limit(dt) )
+        unwrapped_step_adjuster &step_adjuster = m_step_adjuster;
+        if( !step_adjuster.check_step_size_limit(dt) )
         {
             // given dt was above step size limit - adjust and return fail;
-            dt = m_step_adjuster.get_max_dt();
+            dt = step_adjuster.get_max_dt();
             return fail;
         }
 
@@ -428,13 +429,13 @@ public:
         if( max_rel_err > 1.0 )
         {
             // error too big, decrease step size and reject this step
-            dt = m_step_adjuster.decrease_step(dt, max_rel_err, m_stepper.error_order());
+            dt = step_adjuster.decrease_step(dt, max_rel_err, m_stepper.error_order());
             return fail;
         } else
         {
             // otherwise, increase step size and accept
             t += dt;
-            dt = m_step_adjuster.increase_step(dt, max_rel_err, m_stepper.stepper_order());
+            dt = step_adjuster.increase_step(dt, max_rel_err, m_stepper.stepper_order());
             return success;
         }
     }
@@ -505,6 +506,7 @@ private:
     stepper_type m_stepper;
     error_checker_type m_error_checker;
     step_adjuster_type m_step_adjuster;
+    typedef typename unwrap_reference< step_adjuster_type >::type unwrapped_step_adjuster;
 
     resizer_type m_dxdt_resizer;
     resizer_type m_xerr_resizer;
@@ -584,7 +586,7 @@ public:
             const step_adjuster_type &step_adjuster = step_adjuster_type() ,
             const stepper_type &stepper = stepper_type()
     )
-    : m_stepper( stepper ) , m_error_checker( error_checker ) , m_step_adjuster(step_adjuster) ,
+    : m_stepper( stepper ) , m_error_checker( error_checker ) , m_step_adjuster(step_adjuster) , 
       m_first_call( true )
     { }
 
@@ -751,10 +753,11 @@ public:
     controlled_step_result try_step( System system , const StateIn &in , const DerivIn &dxdt_in , time_type &t ,
             StateOut &out , DerivOut &dxdt_out , time_type &dt )
     {
-        if( !m_step_adjuster.check_step_size_limit(dt) )
+        unwrapped_step_adjuster &step_adjuster = m_step_adjuster;
+        if( !step_adjuster.check_step_size_limit(dt) )
         {
             // given dt was above step size limit - adjust and return fail;
-            dt = m_step_adjuster.get_max_dt();
+            dt = step_adjuster.get_max_dt();
             return fail;
         }
 
@@ -770,12 +773,12 @@ public:
         if( max_rel_err > 1.0 )
         {
             // error too big, decrease step size and reject this step
-            dt = m_step_adjuster.decrease_step(dt, max_rel_err, m_stepper.error_order());
+            dt = step_adjuster.decrease_step(dt, max_rel_err, m_stepper.error_order());
             return fail;
         }
         // otherwise, increase step size and accept
         t += dt;
-        dt = m_step_adjuster.increase_step(dt, max_rel_err, m_stepper.stepper_order());
+        dt = step_adjuster.increase_step(dt, max_rel_err, m_stepper.stepper_order());
         return success;
     }
 
@@ -903,6 +906,7 @@ private:
     stepper_type m_stepper;
     error_checker_type m_error_checker;
     step_adjuster_type m_step_adjuster;
+    typedef typename unwrap_reference< step_adjuster_type >::type unwrapped_step_adjuster;
 
     resizer_type m_dxdt_resizer;
     resizer_type m_xerr_resizer;

--- a/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
+++ b/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
@@ -200,7 +200,7 @@ public:
 
 
 
-private:
+protected:
 
     template< class StateIn >
     bool resize_m_xerr( const StateIn &x )

--- a/test/rosenbrock4.cpp
+++ b/test/rosenbrock4.cpp
@@ -127,17 +127,17 @@ BOOST_AUTO_TEST_CASE( test_rosenbrock4_dense_output )
     stepper.calc_state( 0.5 * ( tr.first + tr.second ) , x );
 }
 
+class rosenbrock4_controller_max_dt_adaptable : public rosenbrock4_controller< rosenbrock4< value_type > >
+{
+    public:
+        void set_max_dt(value_type max_dt)
+        {
+            m_max_dt = max_dt;
+        }
+};
+
 BOOST_AUTO_TEST_CASE( test_rosenbrock4_dense_output_ref )
 {
-    class rosenbrock4_controller_max_dt_adaptable : public rosenbrock4_controller< rosenbrock4< value_type > >
-    {
-        public:
-            void set_max_dt(value_type max_dt)
-            {
-                m_max_dt = max_dt;
-            }
-    };
-
     typedef rosenbrock4_dense_output< boost::reference_wrapper< rosenbrock4_controller_max_dt_adaptable > > stepper_type;
     rosenbrock4_controller_max_dt_adaptable  c_stepper;
     stepper_type stepper( boost::ref( c_stepper ) );

--- a/test/rosenbrock4.cpp
+++ b/test/rosenbrock4.cpp
@@ -127,6 +127,24 @@ BOOST_AUTO_TEST_CASE( test_rosenbrock4_dense_output )
     stepper.calc_state( 0.5 * ( tr.first + tr.second ) , x );
 }
 
+BOOST_AUTO_TEST_CASE( test_rosenbrock4_dense_output_ref )
+{
+    typedef rosenbrock4_dense_output< boost::reference_wrapper< rosenbrock4_controller< rosenbrock4< value_type > > > > stepper_type;
+    typedef rosenbrock4_controller< rosenbrock4< value_type > > controlled_stepper_type;
+    controlled_stepper_type  c_stepper;
+    stepper_type stepper( boost::ref( c_stepper ) );
+
+    typedef stepper_type::state_type state_type;
+    typedef stepper_type::value_type stepper_value_type;
+    typedef stepper_type::deriv_type deriv_type;
+    typedef stepper_type::time_type time_type;
+    state_type x( 2 );
+    x( 0 ) = 0.0 ; x(1) = 1.0;
+    stepper.initialize( x , 0.0 , 0.1 );
+    std::pair< value_type , value_type > tr = stepper.do_step( std::make_pair( sys() , jacobi() ) );
+    stepper.calc_state( 0.5 * ( tr.first + tr.second ) , x );
+}
+
 BOOST_AUTO_TEST_CASE( test_rosenbrock4_copy_dense_output )
 {
     typedef rosenbrock4_controller< rosenbrock4< value_type > > controlled_stepper_type;


### PR DESCRIPTION
For efficient simulation of "hybrid" systems the integrator must approach
the sample points where the discrete variables change their value.

(hybrid systems = systems of ODEs which include discrete variables, beeing
internal variables of the system which only change their value at discrete
sample points)

Approaching sample points can be done by adapting the maximal integrator
step size to min(max_step_size, next_sample_point_time - current_time)
before each do_step.

To achive this in odeint for all dense output steppers the following
changes must be done (which does not change the existing API):
- make private members in bulirsch_stoer_dense_out,
  default_step_adjuster, rosenbrock4_controller protected.
- allow std::ref/boost::ref for step_adjuster in controlled_runge_kutta
  and controlled_runge_kutta and for stepper in rosenbrock4_dense_output
  by unwrapping these before use.
This allows to pass the step adjusters by reference to the dense output
steppers which than allows to change the maximal step size (in the step
adjuster) before each call to do_step.