### PR TITLE
Added new typedef system_category to all steppers.

### DIFF
--- a/include/boost/numeric/odeint/stepper/adams_bashforth.hpp
+++ b/include/boost/numeric/odeint/stepper/adams_bashforth.hpp
@@ -36,6 +36,7 @@
 #include <boost/numeric/odeint/util/resizer.hpp>
 
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/stepper/runge_kutta4.hpp>
 #include <boost/numeric/odeint/stepper/extrapolation_stepper.hpp>
 
@@ -99,6 +100,7 @@ public :
     typedef Time time_type;
     typedef Resizer resizer_type;
     typedef stepper_tag stepper_category;
+    typedef explicit_system_tag system_category;
 
     typedef InitializingStepper initializing_stepper_type;
 

--- a/include/boost/numeric/odeint/stepper/adams_bashforth_moulton.hpp
+++ b/include/boost/numeric/odeint/stepper/adams_bashforth_moulton.hpp
@@ -23,6 +23,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -73,6 +74,7 @@ public :
     typedef Resizer resizer_type;
     typedef stepper_tag stepper_category;
     typedef InitializingStepper initializing_stepper_type;
+    typedef explicit_system_tag system_category;
 
     static const size_t steps = Steps;
 #ifndef DOXYGEN_SKIP

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer.hpp
@@ -35,6 +35,7 @@
 #include <boost/numeric/odeint/stepper/controlled_runge_kutta.hpp>
 #include <boost/numeric/odeint/stepper/modified_midpoint.hpp>
 #include <boost/numeric/odeint/stepper/controlled_step_result.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -70,6 +71,7 @@ public:
     typedef Algebra algebra_type;
     typedef Operations operations_type;
     typedef Resizer resizer_type;
+    typedef explicit_system_tag system_category;
 #ifndef DOXYGEN_SKIP
     typedef state_wrapper< state_type > wrapped_state_type;
     typedef state_wrapper< deriv_type > wrapped_deriv_type;

--- a/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
+++ b/include/boost/numeric/odeint/stepper/bulirsch_stoer_dense_out.hpp
@@ -33,6 +33,7 @@
 #include <boost/numeric/odeint/stepper/controlled_runge_kutta.hpp>
 #include <boost/numeric/odeint/stepper/modified_midpoint.hpp>
 #include <boost/numeric/odeint/stepper/controlled_step_result.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -74,6 +75,7 @@ public:
     typedef Operations operations_type;
     typedef Resizer resizer_type;
     typedef dense_output_stepper_tag stepper_category;
+    typedef explicit_system_tag system_category;
 #ifndef DOXYGEN_SKIP
     typedef state_wrapper< state_type > wrapped_state_type;
     typedef state_wrapper< deriv_type > wrapped_deriv_type;

--- a/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
@@ -41,6 +41,7 @@
 
 #include <boost/numeric/odeint/stepper/controlled_step_result.hpp>
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 namespace boost {
 namespace numeric {
@@ -229,6 +230,7 @@ public:
     typedef ErrorChecker error_checker_type;
     typedef StepAdjuster step_adjuster_type;
     typedef explicit_controlled_stepper_tag stepper_category;
+    typedef explicit_system_tag system_category;
 
 #ifndef DOXYGEN_SKIP
     typedef typename stepper_type::wrapped_state_type wrapped_state_type;

--- a/include/boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp
@@ -36,6 +36,7 @@
 
 #include <boost/numeric/odeint/stepper/controlled_step_result.hpp>
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/integrate/max_step_checker.hpp>
 
@@ -81,6 +82,7 @@ public:
     typedef typename stepper_type::resizer_type resizer_type;
     typedef dense_output_stepper_tag stepper_category;
     typedef dense_output_runge_kutta< Stepper > dense_output_stepper_type;
+    typedef explicit_system_tag system_category;
 
 
     /**

--- a/include/boost/numeric/odeint/stepper/euler.hpp
+++ b/include/boost/numeric/odeint/stepper/euler.hpp
@@ -21,6 +21,7 @@
 
 
 #include <boost/numeric/odeint/stepper/base/explicit_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/util/resizer.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
@@ -64,6 +65,7 @@ public :
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::stepper_type stepper_type;

--- a/include/boost/numeric/odeint/stepper/implicit_euler.hpp
+++ b/include/boost/numeric/odeint/stepper/implicit_euler.hpp
@@ -25,6 +25,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 #include <boost/numeric/odeint/util/unwrap_reference.hpp>
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/util/ublas_wrapper.hpp>
 #include <boost/numeric/odeint/util/is_resizeable.hpp>
@@ -64,6 +65,7 @@ public:
     typedef Resizer resizer_type;
     typedef stepper_tag stepper_category;
     typedef implicit_euler< ValueType , Resizer > stepper_type;
+    typedef implicit_system_tag system_category;
 
     implicit_euler( value_type epsilon = 1E-6 )
     : m_epsilon( epsilon ) 

--- a/include/boost/numeric/odeint/stepper/modified_midpoint.hpp
+++ b/include/boost/numeric/odeint/stepper/modified_midpoint.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <boost/numeric/odeint/stepper/base/explicit_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/util/resizer.hpp>
 #include <boost/numeric/odeint/util/is_resizeable.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
@@ -69,6 +70,7 @@ public :
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
     typedef typename stepper_base_type::stepper_type stepper_type;
+    typedef explicit_system_tag system_category;
 
 
     modified_midpoint( unsigned short steps = 2 , const algebra_type &algebra = algebra_type() )

--- a/include/boost/numeric/odeint/stepper/rosenbrock4.hpp
+++ b/include/boost/numeric/odeint/stepper/rosenbrock4.hpp
@@ -28,6 +28,7 @@
 #include <boost/numeric/ublas/lu.hpp>
 
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/util/ublas_wrapper.hpp>
 #include <boost/numeric/odeint/util/is_resizeable.hpp>
@@ -141,6 +142,7 @@ public:
     typedef Resizer resizer_type;
     typedef Coefficients rosenbrock_coefficients;
     typedef stepper_tag stepper_category;
+    typedef implicit_system_tag system_category;
     typedef unsigned short order_type;
 
     typedef state_wrapper< state_type > wrapped_state_type;

--- a/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
+++ b/include/boost/numeric/odeint/stepper/rosenbrock4_controller.hpp
@@ -23,6 +23,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 
 #include <boost/numeric/odeint/stepper/controlled_step_result.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
 
 #include <boost/numeric/odeint/util/copy.hpp>
@@ -52,6 +53,7 @@ public:
     typedef typename stepper_type::wrapped_deriv_type wrapped_deriv_type;
     typedef typename stepper_type::resizer_type resizer_type;
     typedef controlled_stepper_tag stepper_category;
+    typedef implicit_system_tag system_category;
 
     typedef rosenbrock4_controller< Stepper > controller_type;
 

--- a/include/boost/numeric/odeint/stepper/rosenbrock4_dense_output.hpp
+++ b/include/boost/numeric/odeint/stepper/rosenbrock4_dense_output.hpp
@@ -25,6 +25,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 
 #include <boost/numeric/odeint/stepper/rosenbrock4_controller.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/util/is_resizeable.hpp>
 
 #include <boost/numeric/odeint/integrate/max_step_checker.hpp>
@@ -50,6 +51,7 @@ public:
     typedef typename stepper_type::wrapped_deriv_type wrapped_deriv_type;
     typedef typename stepper_type::resizer_type resizer_type;
     typedef dense_output_stepper_tag stepper_category;
+    typedef implicit_system_tag system_category;
 
     typedef rosenbrock4_dense_output< ControlledStepper > dense_output_stepper_type;
 

--- a/include/boost/numeric/odeint/stepper/runge_kutta4.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta4.hpp
@@ -25,6 +25,7 @@
 #include <boost/fusion/container/generation/make_vector.hpp>
 
 #include <boost/numeric/odeint/stepper/explicit_generic_rk.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -129,6 +130,7 @@ public:
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::wrapped_state_type wrapped_state_type;

--- a/include/boost/numeric/odeint/stepper/runge_kutta4_classic.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta4_classic.hpp
@@ -22,6 +22,7 @@
 
 
 #include <boost/numeric/odeint/stepper/base/explicit_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -71,6 +72,7 @@ public :
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::stepper_type stepper_type;

--- a/include/boost/numeric/odeint/stepper/runge_kutta_cash_karp54.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta_cash_karp54.hpp
@@ -22,6 +22,7 @@
 #include <boost/fusion/container/generation/make_vector.hpp>
 
 #include <boost/numeric/odeint/stepper/explicit_error_generic_rk.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -172,6 +173,7 @@ public:
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_typ;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::stepper_type stepper_type;

--- a/include/boost/numeric/odeint/stepper/runge_kutta_cash_karp54_classic.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta_cash_karp54_classic.hpp
@@ -23,6 +23,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 
 #include <boost/numeric/odeint/stepper/base/explicit_error_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -76,6 +77,7 @@ public :
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::wrapped_state_type wrapped_state_type;

--- a/include/boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp
@@ -23,6 +23,7 @@
 #include <boost/numeric/odeint/util/bind.hpp>
 
 #include <boost/numeric/odeint/stepper/base/explicit_error_stepper_fsal_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -76,6 +77,7 @@ public :
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::stepper_type stepper_type;

--- a/include/boost/numeric/odeint/stepper/runge_kutta_fehlberg78.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta_fehlberg78.hpp
@@ -23,6 +23,7 @@
 #include <boost/fusion/container/generation/make_vector.hpp>
 
 #include <boost/numeric/odeint/stepper/explicit_error_generic_rk.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -317,6 +318,7 @@ public:
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::operations_type operations_type;
     typedef typename stepper_base_type::resizer_type resizer_type;
+    typedef explicit_system_tag system_category;
 
     #ifndef DOXYGEN_SKIP
     typedef typename stepper_base_type::stepper_type stepper_type;

--- a/include/boost/numeric/odeint/stepper/symplectic_euler.hpp
+++ b/include/boost/numeric/odeint/stepper/symplectic_euler.hpp
@@ -20,6 +20,7 @@
 
 
 #include <boost/numeric/odeint/stepper/base/symplectic_rkn_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
@@ -91,6 +92,7 @@ public:
 #endif
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::value_type value_type;
+    typedef symplectic_or_simple_symplectic_system_tag system_category;
 
 
     symplectic_euler( const algebra_type &algebra = algebra_type() )

--- a/include/boost/numeric/odeint/stepper/symplectic_rkn_sb3a_m4_mclachlan.hpp
+++ b/include/boost/numeric/odeint/stepper/symplectic_rkn_sb3a_m4_mclachlan.hpp
@@ -21,6 +21,7 @@
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
 #include <boost/numeric/odeint/algebra/operations_dispatcher.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/util/resizer.hpp>
 
@@ -111,6 +112,7 @@ public:
 #endif
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::value_type value_type;
+    typedef symplectic_or_simple_symplectic_system_tag system_category;
 
 
     symplectic_rkn_sb3a_m4_mclachlan( const algebra_type &algebra = algebra_type() )

--- a/include/boost/numeric/odeint/stepper/symplectic_rkn_sb3a_mclachlan.hpp
+++ b/include/boost/numeric/odeint/stepper/symplectic_rkn_sb3a_mclachlan.hpp
@@ -20,6 +20,7 @@
 
 
 #include <boost/numeric/odeint/stepper/base/symplectic_rkn_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 
 #include <boost/numeric/odeint/algebra/range_algebra.hpp>
 #include <boost/numeric/odeint/algebra/default_operations.hpp>
@@ -114,6 +115,7 @@ public:
 #endif
     typedef typename stepper_base_type::algebra_type algebra_type;
     typedef typename stepper_base_type::value_type value_type;
+    typedef symplectic_or_simple_symplectic_system_tag system_category;
 
 
     symplectic_rkn_sb3a_mclachlan( const algebra_type &algebra = algebra_type() )

--- a/include/boost/numeric/odeint/stepper/system_categories.hpp
+++ b/include/boost/numeric/odeint/stepper/system_categories.hpp
@@ -1,0 +1,44 @@
+/*
+ [auto_generated]
+ boost/numeric/odeint/stepper/system_categories.hpp
+
+ [begin_description]
+ Definition of all system categories.
+ [end_description]
+
+ Copyright 2017 Markus Friedrich
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+
+#ifndef BOOST_NUMERIC_ODEINT_STEPPER_SYSTEM_CATEGORIES_HPP_INCLUDED
+#define BOOST_NUMERIC_ODEINT_STEPPER_SYSTEM_CATEGORIES_HPP_INCLUDED
+
+namespace boost {
+namespace numeric {
+namespace odeint {
+
+
+/*
+ * Tags to specify system types
+ *
+ * These tags can be used to detect which system category is used
+ */
+
+struct explicit_system_tag {};
+struct second_order_system_tag {};
+struct symplectic_system_tag {};
+struct simple_symplectic_system_tag {};
+struct symplectic_or_simple_symplectic_system_tag {};
+struct implicit_system_tag {};
+
+
+} // odeint
+} // numeric
+} // boost
+
+
+#endif // BOOST_NUMERIC_ODEINT_STEPPER_SYSTEM_CATEGORIES_HPP_INCLUDED

--- a/include/boost/numeric/odeint/stepper/velocity_verlet.hpp
+++ b/include/boost/numeric/odeint/stepper/velocity_verlet.hpp
@@ -19,6 +19,7 @@
 #define BOOST_NUMERIC_ODEINT_STEPPER_VELOCITY_VERLET_HPP_DEFINED
 
 #include <boost/numeric/odeint/stepper/base/algebra_stepper_base.hpp>
+#include <boost/numeric/odeint/stepper/system_categories.hpp>
 #include <boost/numeric/odeint/stepper/stepper_categories.hpp>
 
 #include <boost/numeric/odeint/algebra/algebra_dispatcher.hpp>
@@ -71,6 +72,7 @@ public:
     typedef TimeSq time_square_type;
     typedef Resizer resizer_type;
     typedef stepper_tag stepper_category;
+    typedef second_order_system_tag system_category;
 
     typedef unsigned short order_type;
 

--- a/test/bulirsch_stoer.cpp
+++ b/test/bulirsch_stoer.cpp
@@ -84,6 +84,7 @@ BOOST_AUTO_TEST_CASE( test_bulirsch_stoer )
 {
     typedef bulirsch_stoer< state_type > stepper_type;
     stepper_type stepper( 1E-9 , 1E-9 , 1.0 , 0.0 );
+    BOOST_STATIC_ASSERT_MSG( ( boost::is_same< stepper_type::system_category , explicit_system_tag >::value ) , "System category" );
 
     state_type x;
     x[0] = 10.0 ; x[1] = 10.0 ; x[2] = 5.0;

--- a/test/rosenbrock4.cpp
+++ b/test/rosenbrock4.cpp
@@ -70,6 +70,7 @@ BOOST_AUTO_TEST_CASE( test_rosenbrock4_stepper )
 {
     typedef rosenbrock4< value_type > stepper_type;
     stepper_type stepper;
+    BOOST_STATIC_ASSERT_MSG( ( boost::is_same< stepper_type::system_category , implicit_system_tag >::value ) , "System category" );
 
     typedef stepper_type::state_type state_type;
     typedef stepper_type::value_type stepper_value_type;

--- a/test/symplectic_steppers.cpp
+++ b/test/symplectic_steppers.cpp
@@ -155,6 +155,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_assoc_types , Stepper , vector_steppers< ini
 
     BOOST_STATIC_ASSERT_MSG( ( boost::is_same< typename Stepper::resizer_type , initially_resizer >::value ) , "Resizer type" );
     BOOST_STATIC_ASSERT_MSG( ( boost::is_same< typename Stepper::stepper_category , stepper_tag >::value ) , "Stepper category" );
+
+    BOOST_STATIC_ASSERT_MSG(
+        ( boost::is_same< typename Stepper::system_category , symplectic_or_simple_symplectic_system_tag >::value ) , 
+        "System category" );
 }
 
 

--- a/test/velocity_verlet.cpp
+++ b/test/velocity_verlet.cpp
@@ -123,6 +123,7 @@ BOOST_AUTO_TEST_SUITE( velocity_verlet_test )
 BOOST_FIXTURE_TEST_CASE( test_with_array_ref , velocity_verlet_fixture )
 {
     array_stepper stepper;
+    BOOST_STATIC_ASSERT_MSG( ( boost::is_same< array_stepper::system_category , second_order_system_tag >::value ) , "System category" );
     array_type q , p ;
     init_state( q , p );
     stepper.do_step( ode() , std::make_pair( boost::ref( q ) , boost::ref( p ) ) , 0.0 , 0.01 );


### PR DESCRIPTION
This new typedef must be one of
- explicit_system_tag
- second_order_system_tag
- symplectic_system_tag
- simple_symplectic_system_tag
- symplectic_or_simple_symplectic_system_tag
- implicit_system_tag
and defines the type of the system the stepper handles.
This can be usefull to automatically provide a proper system to a
stepper using template spezialization.