### PR TITLE
Fixed incorrect constant in Dormand–Prince Runge–Kutta Butcher tableau.

### DIFF
--- a/include/boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp
+++ b/include/boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp
@@ -174,7 +174,7 @@ public :
         const value_type dc4 = c4 - static_cast<value_type> ( 393 ) / static_cast<value_type>( 640 );
         const value_type dc5 = c5 - static_cast<value_type> ( -92097 ) / static_cast<value_type>( 339200 );
         const value_type dc6 = c6 - static_cast<value_type> ( 187 ) / static_cast<value_type>( 2100 );
-        const value_type dc7 = static_cast<value_type>( -1 ) / static_cast<value_type> ( 40 );
+        const value_type dc7 = static_cast<value_type>( 1 ) / static_cast<value_type> ( 40 );
 
         /* ToDo: copy only if &dxdt_in == &dxdt_out ? */
         if( same_instance( dxdt_in , dxdt_out ) )


### PR DESCRIPTION
I already submitted this to boostorg/odeint but was told I should submit it here instead.

This constant somehow has the incorrect sign when compared to the actual Dormand-Prince Runge-Kutta butcher tableau. This causes the ODE solver to be a bit misguided as it tries to guess steps and estimate error and in the end, while it still works, it does not work as efficiently as it ought to. The entire butcher tableau was created in an internally balanced way but this coefficient being incorrect means that that the boost implementation is much less effective at solving correctly, when compared to another solver with correct coefficients, for the same solver tolerances.

Here are a few references showing that the 1/40 coefficient ought to be positive (look at the lower-right corner of the table):

https://en.wikipedia.org/wiki/Dormand%E2%80%93Prince_method

Here is a paper that clearly has this coefficient as positive on page 1 equation 9:

http://depa.fquim.unam.mx/amyd/archivero/DormandPrince_19856.pdf

Here is a link to the original Dormand Prince paper published in 1980 which I was able to find freely available on sciencedirect.com (Page 5 of the PDF, table 2, again in the lower-right corner of the table):

https://www.sciencedirect.com/science/article/pii/0771050X80900133?via%3Dihub

I hope these references are sufficient to show that the coefficient is incorrect as it currently stands. We have used this ODE solver and found the solving to work much better with the coefficient corrected. This library has been very useful for us, thank you for all of the development work!